### PR TITLE
Ignore HTML comments in slots

### DIFF
--- a/tests-vue3/tests/index.spec.ts
+++ b/tests-vue3/tests/index.spec.ts
@@ -2,7 +2,7 @@ import { mount } from "@vue/test-utils";
 import VueWordHighlighter from "../../vue-word-highlighter/src/components";
 import WrappedWordHighlighter from "./fixtures/WrappedWordHighlighter.vue";
 import { describe, it, expect } from "vitest";
-import { createTextVNode, h, VNode } from "vue-demi";
+import { createCommentVNode, createTextVNode, h, VNode } from "vue-demi";
 
 describe("VueWordHighlighter", () => {
   const createWrapper = (
@@ -342,6 +342,10 @@ foo <mark class="red-color" style="font-weight: bold">dummy</mark>
       const nodes = [
         h("h1", {}, "h1 dummy"),
         createTextVNode("foo dummy"),
+        h("p", {}, [
+          createCommentVNode("this is dummy comment"),
+          createTextVNode("test"),
+        ]),
         h("p", {}, [h("b", "hoge dummy")]),
       ];
 
@@ -360,6 +364,9 @@ foo <mark class="red-color" style="font-weight: bold">dummy</mark>
         `
 <h1><span class="">h1 <mark class="" style="">dummy</mark></span></h1>
 <span class=""><mark class="" style="">foo</mark> <mark class="" style="">dummy</mark></span>
+<p>
+  <!--this is dummy comment-->test
+</p>
 <p><b><span class="">hoge <mark class="" style="">dummy</mark></span></b></p>
       `.trim()
       );

--- a/vue-word-highlighter/src/components/index.ts
+++ b/vue-word-highlighter/src/components/index.ts
@@ -1,4 +1,12 @@
-import { defineComponent, h, install, PropType, isVue3, VNode } from "vue-demi";
+import {
+  defineComponent,
+  h,
+  install,
+  PropType,
+  isVue3,
+  VNode,
+  Comment,
+} from "vue-demi";
 import { createHighlightWordChunk } from "../utils/createHighlightWordChunk";
 import { extractDefaultSlotsText } from "../utils/extractDefaultSlotsText";
 import { extractMatchesStrings } from "../utils/extractMatchesStrings";
@@ -142,8 +150,10 @@ export default defineComponent({
         // only supported nested slots in Vue 3
         if (ctx.slots && ctx.slots.default) {
           const createHighlightedNode = (node: VNode): VNode => {
-            // if node have a text, it's a text node
-            if (typeof node.children == "string") {
+            if (node.type === Comment) {
+              return node;
+            }
+            if (typeof node.children === "string") {
               const highlightWordChunk = createHighlightWordChunk(
                 node.children,
                 {


### PR DESCRIPTION
Ignore HTML comments in slots. This can work only with Vue3.


fix #687 